### PR TITLE
Removed leftover code and moved Firebase specific code back to where it belongs

### DIFF
--- a/lib/creation_time_item_serializable.dart
+++ b/lib/creation_time_item_serializable.dart
@@ -5,10 +5,11 @@ import './item_serializable.dart';
 /// Written by: @pariterre and @Guibi1
 abstract class CreationTimeItemSerializable extends ItemSerializable {
   /// Creates an [CreationTimeItemSerializable] with the original [creationTimeStamp].
-  CreationTimeItemSerializable({String? id, int? creationTimeStamp})
-      : creationTimeStamp =
-            creationTimeStamp ?? DateTime.now().microsecondsSinceEpoch,
-        super(id: id);
+  CreationTimeItemSerializable({
+    super.id,
+    int? creationTimeStamp,
+  }) : creationTimeStamp =
+            creationTimeStamp ?? DateTime.now().microsecondsSinceEpoch;
 
   /// Creates an [CreationTimeItemSerializable] from a map of serialized items.
   CreationTimeItemSerializable.fromSerialized(map)

--- a/lib/database_list_provided.dart
+++ b/lib/database_list_provided.dart
@@ -3,26 +3,12 @@ import 'list_provided.dart';
 
 abstract class DatabaseListProvided<T> extends ListProvided<T> {
   /// Creates an empty [DatabaseListProvided].
-  DatabaseListProvided({
-    required this.pathToData,
-    String? pathToAvailableDataIds,
-  }) : _pathToAvailableDataIds = pathToAvailableDataIds ?? '$pathToData-ids';
+  DatabaseListProvided();
 
-  /// You can't use this function with [ListFirebase], as it already saves its content in the cloud automagically.
+  /// You can't use this function with [DatabaseListProvided], as it already saves its content in the cloud automagically.
   @override
   void deserialize(map) {
     throw const ShouldNotCall(
         'You should not use this function with a Database List Provided.');
-  }
-
-  /// The path to the stored data inside the database.
-  final String pathToData;
-
-  /// The path to the list of available ids inside the database.
-  String _pathToAvailableDataIds;
-  // ignore: unnecessary_getters_setters
-  String get pathToAvailableDataIds => _pathToAvailableDataIds;
-  set pathToAvailableDataIds(String newPath) {
-    _pathToAvailableDataIds = newPath;
   }
 }

--- a/lib/firebase_list_provided.dart
+++ b/lib/firebase_list_provided.dart
@@ -16,8 +16,9 @@ abstract class FirebaseListProvided<T> extends DatabaseListProvided<T> {
     required String pathToData,
     String? pathToAvailableDataIds,
   }) : super(
-            pathToData: pathToData,
-            pathToAvailableDataIds: pathToAvailableDataIds) {
+          pathToData: pathToData,
+          pathToAvailableDataIds: pathToAvailableDataIds,
+        ) {
     _listenToDatabase();
   }
 

--- a/lib/firebase_list_provided.dart
+++ b/lib/firebase_list_provided.dart
@@ -13,12 +13,9 @@ import 'database_list_provided.dart';
 abstract class FirebaseListProvided<T> extends DatabaseListProvided<T> {
   /// Creates a [FirebaseListProvided] with the specified data path and ids path.
   FirebaseListProvided({
-    required String pathToData,
+    required this.pathToData,
     String? pathToAvailableDataIds,
-  }) : super(
-          pathToData: pathToData,
-          pathToAvailableDataIds: pathToAvailableDataIds,
-        ) {
+  }) : _pathToAvailableDataIds = pathToAvailableDataIds ?? '$pathToData-ids' {
     _listenToDatabase();
   }
 
@@ -113,8 +110,16 @@ abstract class FirebaseListProvided<T> extends DatabaseListProvided<T> {
     }
   }
 
+  /// The path to the stored data inside the database.
+  final String pathToData;
+
   /// The path to the list of available ids inside the database.
-  @override
+  String _pathToAvailableDataIds;
+
+  /// The path to the list of available ids inside the database.
+  String get pathToAvailableDataIds => _pathToAvailableDataIds;
+
+  /// This will cancel all database subscriptions, then clear all data, then listen to the new path of ids
   set pathToAvailableDataIds(String newPath) {
     _availableDataIdsAddedSubscription.cancel();
     _availableDataIdsRemovedSubscription.cancel();
@@ -122,15 +127,17 @@ abstract class FirebaseListProvided<T> extends DatabaseListProvided<T> {
 
     super.clear();
 
-    super.pathToAvailableDataIds = newPath;
+    _pathToAvailableDataIds = newPath;
     _listenToDatabase();
   }
 
+  // The Firebase subscriptions
   late StreamSubscription<DatabaseEvent> _availableDataIdsAddedSubscription;
   late StreamSubscription<DatabaseEvent> _availableDataIdsRemovedSubscription;
 
   final Map<String, StreamSubscription<DatabaseEvent>> _dataSubscriptions = {};
 
+  // Firebase Reference getters
   DatabaseReference get _availableIdsRef =>
       FirebaseDatabase.instance.ref(pathToAvailableDataIds);
   DatabaseReference get _dataRef => FirebaseDatabase.instance.ref(pathToData);

--- a/lib/item_serializable.dart
+++ b/lib/item_serializable.dart
@@ -22,9 +22,6 @@ abstract class ItemSerializable {
     return out;
   }
 
-  /// Deserializes the current object
-  ItemSerializable deserializeItem(map);
-
   /// The global id of each instances.
   final String id;
 }

--- a/lib/list_provided.dart
+++ b/lib/list_provided.dart
@@ -7,11 +7,10 @@ import 'list_serializable.dart';
 /// Written by: @pariterre and @Guibi1
 abstract class ListProvided<T> extends ListSerializable<T> with ChangeNotifier {
   /// Creates an empty [ListProvided].
-  ListProvided() : super();
+  ListProvided();
 
   /// Creates a [ListProvided] from a map of serialized items.
-  ListProvided.fromSerialized(map)
-      : super.fromSerialized(map);
+  ListProvided.fromSerialized(map) : super.fromSerialized(map);
 
   @override
   void add(T item, {bool notify = true}) {


### PR DESCRIPTION
This PR contains no breaking changes, only QOL and clarity improvements.

- Removed some Constructor code to be more concise. (aka: super());
- Removed `ItemSerializable deserializeItem(map);` from `ItemSerializable` which was a duplicate of `fromSerialized` and that was never used (the class that herited from `ItemSerializable` will need to remove this function);
- Moved back the code for Firebase into `FirebaseListProvided`;

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cr-crme/enhanced_containers/9)
<!-- Reviewable:end -->
